### PR TITLE
Fixed image misalignment on Firefox

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -381,7 +381,7 @@ header {
 }
 
 .button {
-	transition: transform 100ms ease-in;
+	transition: transform 100ms ease-in, border-radius 100ms ease-in;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -393,7 +393,8 @@ header {
 }
 
 .button:hover, .button:focus {
-	transform: scale(1.02);
+	transform: scale(1.03);
+	border-radius: 8px;
 }
 
 .button:active {
@@ -528,8 +529,6 @@ footer {
 	.feature-illustration {
 		flex: 1;
 		height: 100%;
-		width: auto;
-		/* width: 50%; */
 	}
 	
 	.feature__text-first .feature-desc{
@@ -538,7 +537,6 @@ footer {
 
 	.feature-desc {
 		flex: 1;
-		/* width: 50%; */
 		color: var(--sourcery-900);
 	}
 


### PR DESCRIPTION
Sorry to push out another tiny patch but I opened up prod on Firefox today and it had images jumbled in a completely different, but equally stupid easy way to fix like Safari. I'll definitely have to test future revisions more in the future. CSS Grid is both a blessing and a curse:
![image](https://user-images.githubusercontent.com/9309968/96404756-ad536100-11a9-11eb-8662-eaec333e1db6.png)

