### PR TITLE
potential fix for uploads from mobile phones

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,12 @@
     "lodash.throttle": "^4.1.1",
     "material-design-icons-iconfont": "^5.0.1",
     "md5": "^2.2.1",
+    "mime-types": "^2.1.28",
     "nuxt": "^2.14.12",
     "paymentfont": "^1.2.5",
     "register-service-worker": "^1.7.1",
     "search-insights": "^1.4.0",
+    "uuid": "^8.3.2",
     "vue-cookie-law": "^1.11.0",
     "vue-instantsearch": "^2.7.0"
   },

--- a/store/request.js
+++ b/store/request.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid'
+import mime from 'mime-types'
 /**
  * Any properties for the meta state should be added
  * to this function.
@@ -104,6 +106,9 @@ export const actions = {
         // Default number of pages for an attachment
         let pages = 1
 
+        // Stored Filename will become UUID.extension
+        const storedFileName = `${uuidv4()}.${mime.extension(file.type)}`
+
         // If it's a PDF, we need to count the number of pages
         if (file.type === 'application/pdf') {
             pages = await countPages(file)
@@ -113,7 +118,7 @@ export const actions = {
             const storageRef = this.$fire.storage.ref(
                 `jobs/${state.document.id}/images/`
             )
-            const imageRef = storageRef.child(file.name.toLowerCase())
+            const imageRef = storageRef.child(storedFileName)
             const uploadTask = imageRef.put(file)
 
             uploadTask.on(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8466,7 +8466,7 @@ mime-db@1.45.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
   integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
 
-mime-types@^2.0.8, mime-types@^2.1.19:
+mime-types@^2.0.8, mime-types@^2.1.19, mime-types@^2.1.28:
   version "2.1.28"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.28.tgz#1160c4757eab2c5363888e005273ecf79d2a0ecd"
   integrity sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==
@@ -12892,7 +12892,7 @@ uuid@^3.0.0, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@^8.0.0:
+uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
Some mobile devices upload every camera image as the same file name, sometimes causing collisions on the storage site.

This potential fix uses uuid to rename upload files and avoid collisions in storage.