### PR TITLE
emulator data is saved and loaded to/from .emulator-data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ sw.*
 /functions
 /ui-debug.log
 /firebase-debug.log
+/.emulator-data
 
 # eslint
 /.eslintcache

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "nuxt",
     "build": "nuxt build",
     "start": "nuxt start",
-    "local": "concurrently -k \"firebase emulators:start\" \"EMULATOR=local nuxt\"",
+    "local": "concurrently -k \"firebase emulators:start --import=.emulator-data --export-on-exit\" \"EMULATOR=local nuxt\"",
     "generate": "nuxt generate",
     "lint:js": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "lint": "yarn lint:js",


### PR DESCRIPTION
Minor update to ensure that the state of firestore collections and auth is saved.

Upon exit, the emulator will export any auth and collection data to `.emulator-data` directory.

Upon start, the emulator will import auth/collection data from the same directory, if it exists.