### PR TITLE
hide ratings from UI

### DIFF
--- a/pages/request/_id.vue
+++ b/pages/request/_id.vue
@@ -70,7 +70,7 @@
 
         <Attachments />
 
-        <v-card v-if="isComplete" class="mt-3">
+        <!-- <v-card v-if="isComplete" class="mt-3">
           <v-card-title>
             <div class="text-h5" v-html="!isRatingSet ? 'Please Rate the Sourcerer' : 'Thank you for rating your Sourcerer!'" />
           </v-card-title>
@@ -87,7 +87,7 @@
               Save
             </v-btn>
           </v-card-actions>
-        </v-card>
+        </v-card> -->
       </template>
     </v-flex>
   </v-layout>
@@ -181,14 +181,14 @@ export default {
                     console.log(error)
                 })
             }
-        },
-        setRating () {
-            if (confirm(`This action cannot be undone. Would you like to rate this Sourcerer ${this.rating} stars?`)) {
-                this.$fire.firestore.collection('requests').doc(this.record.id).set({
-                    userRating: this.rating
-                }, { merge: true })
-            }
         }
+        // setRating () {
+        //     if (confirm(`This action cannot be undone. Would you like to rate this Sourcerer ${this.rating} stars?`)) {
+        //         this.$fire.firestore.collection('requests').doc(this.record.id).set({
+        //             userRating: this.rating
+        //         }, { merge: true })
+        //     }
+        // }
     }
 }
 </script>


### PR DESCRIPTION
Fixes #217 , this only removes from the UI and does not touch terms/privacy.

Do we think terms/privacy need to be adjusted as well? I figured they might still be relevant language since ratings were 'at least once' recorded, and are likely to come back.  Can remove if we feel it doesn't make sense.
