### PR TITLE
Feature/create request

### DIFF
--- a/components/add-card.vue
+++ b/components/add-card.vue
@@ -84,7 +84,6 @@ export default {
         })
     },
     async mounted () {
-        console.log(this.value)
         // Get the client secret and store it
         const { data: { client_secret } } = await this.setupIntents()
         this.client_secret = client_secret

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -171,7 +171,7 @@ export default {
         middleware: [
             'auth-guard',
             'user-meta',
-            'account-type',
+            // 'account-type',
             'onboarding-complete'
         ]
     },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -214,7 +214,7 @@ export default {
                 // if EMULATOR===local, use the Firestore Emulators
                 emulatorPort: env.EMULATOR === 'local' ? 8080 : undefined
             },
-            functions: true,
+            functions: env.EMULATOR === 'local' ? { emulatorPort: 5001 } : true,
             storage: true,
             remoteConfig: true
         }

--- a/pages/request/create.vue
+++ b/pages/request/create.vue
@@ -137,7 +137,7 @@
                 </v-btn>
               </v-card-actions> -->
             </v-card>
-            <v-item-group v-model="request.repository_id" mandatory>
+            <v-item-group mandatory>
               <v-item
                 v-for="repo in repositories"
                 v-slot="{ toggle }"
@@ -191,7 +191,7 @@
                           <v-btn
                             color="white"
                             class="black--text"
-                            @click="formState++; request.repository_id = repo.id"
+                            @click="selectRepository(repo.id)"
                           >
                             Select
                           </v-btn>
@@ -448,6 +448,11 @@ export default {
         console.log(this.repositories)
     },
     methods: {
+        selectRepository (id) {
+            this.request.repository_id = id
+            this.$store.commit('create/setRepositoryId', id)
+            this.formState++
+        },
         submitRequest () {
             this.isSaving = true
             this.$store.dispatch('create/insert').then((doc) => {

--- a/pages/request/create.vue
+++ b/pages/request/create.vue
@@ -353,7 +353,8 @@ export default {
         try {
             repositories = await app.$fire.firestore
                 .collection('repositories')
-                .where('organization', '!=', '')
+                // .where('organization', '!=', '') // This is the correct way, but for demo purposes, only show our partners.  Cannot combine != queries.
+                .where('institution', 'in', ['Folger Shakespeare Library', 'UConn', 'Northeastern University', 'Hartford Public Library'])
                 .orderBy('organization')
                 .orderBy('name', 'asc')
                 .get()

--- a/pages/request/history.vue
+++ b/pages/request/history.vue
@@ -27,7 +27,7 @@
               <v-list-item-subtitle>No past requests found.</v-list-item-subtitle>
             </v-list-item-content>
             <v-list-item-action>
-              <v-btn color="primary" text to="/requests/create">
+              <v-btn color="primary" text to="/request/create">
                 Create <span class="hidden-sm-and-down">&nbsp;Request</span>
                 <v-icon right>
                   mdi-open-in-new

--- a/store/create.js
+++ b/store/create.js
@@ -153,7 +153,7 @@ export const actions = {
      */
     // delete: ({state, commit, dispatch}) => $fire.firestore.collection('requests').doc(state.id).delete(),
     async insert ({ state, commit, dispatch, rootGetters }) {
-    // Generate a label for the request
+        // Generate a label for the request
         commit('setLabel')
 
         // Created now


### PR DESCRIPTION
Fixes #218 , this does a few things:

1. Limits the repositories shown to only the desired partner institutions, for now.
2. Fixes a bug with the request flow where a repository ID would not be persisted through the request.
3. Fixes a bug where the account-type middleware was being activated, which is only intended for P2P
4. Adds some config for local emulation.
5. Fixes a bug on the request history screen where a button had an incorrect route.

I made some small adjustments to the dataset to accomodate, basically just adding organizations/institutions where necessary and indexes to query appropriately.

I did not add Hartford to the dataset yet - as I wanted to confirm the details of that archive location with the group.  Also it looks like a lot of these orgs will need images.

All other request related things seem to be more related to #207 , notifications and those showing up for those users, so we will track there on a separate PR.
