### PR TITLE
commenting out all references on front-end to payouts

### DIFF
--- a/pages/account/payouts.vue
+++ b/pages/account/payouts.vue
@@ -8,7 +8,7 @@
           Payouts
         </v-card-title>
         <v-card-text>
-          <p v-if="!hasStripeID">
+          <!-- <p v-if="!hasStripeID">
             Before accepting payments, you must configure your payout options.
           </p>
           <p v-if="hasStripeID">
@@ -16,12 +16,13 @@
           </p>
           <p v-if="hasStripeID">
             Estimated Balance: {{ balance }}
-          </p>
+          </p> -->
+          <p>Payouts are currently not active.</p>
         </v-card-text>
 
         <v-card-actions>
           <v-spacer />
-          <connect-button />
+          <!-- <connect-button /> -->
         </v-card-actions>
       </v-card>
     </v-flex>
@@ -29,13 +30,13 @@
 </template>
 
 <script>
-import connectButton from '~/components/connect-button.vue'
+// import connectButton from '~/components/connect-button.vue'
 
 export default {
     name: 'Payouts',
-    components: {
-        'connect-button': connectButton
-    },
+    // components: {
+    //     'connect-button': connectButton
+    // },
     data () {
         return {
             stripeConnect: null

--- a/pages/jobs/index.vue
+++ b/pages/jobs/index.vue
@@ -11,7 +11,7 @@
         During the beta, users can request documents located in the Boston and New York metro areas, and at the University of Connecticut.
       </v-alert>
 
-      <v-alert
+      <!-- <v-alert
         :value="!canReceivePayments"
         type="warning"
         class="mt-4 mb-4"
@@ -22,7 +22,7 @@
             Configure
           </v-btn>
         </v-layout>
-      </v-alert>
+      </v-alert> -->
 
       <v-card
         outlined
@@ -107,7 +107,7 @@
                     <br>
                     {{ job.data().repository.city }}, {{ job.data().repository.state }} {{ job.data().repository.postal_code }}
                   </v-flex>
-                  <v-flex>
+                  <!-- <v-flex>
                     <p
                       color="primary--text"
                       class="primary--text text-h3 font-weight-bold"
@@ -116,7 +116,7 @@
                     <p class="grey--text text--darken-1">
                       (Estimated payout for a {{ job.data().pages }} page fulfillment.)
                     </p>
-                  </v-flex>
+                  </v-flex> -->
                 </v-layout>
               </v-container>
               <v-card-actions>

--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -540,7 +540,7 @@
           </v-list-item>
         </v-list>
         <v-divider />
-        <v-list v-if="hasStripeID" two-line subheader>
+        <!-- <v-list v-if="hasStripeID" two-line subheader>
           <v-subheader>
             Payouts
           </v-subheader>
@@ -579,7 +579,7 @@
               <connect-button />
             </v-list-item-action>
           </v-list-item>
-        </v-list>
+        </v-list> -->
       </v-card>
       <v-card
         outlined
@@ -785,7 +785,7 @@
 
 <script>
 import addCard from '~/components/add-card.vue'
-import connectButton from '~/components/connect-button.vue'
+// import connectButton from '~/components/connect-button.vue'
 import privacyPolicy from '~/pages/privacy.vue'
 import termsOfService from '~/pages/terms.vue'
 
@@ -793,7 +793,7 @@ export default {
     name: 'Settings',
     components: {
         'add-card': addCard,
-        'connect-button': connectButton,
+        // 'connect-button': connectButton,
         'privacy-policy': privacyPolicy,
         'terms-of-service': termsOfService
     },


### PR DESCRIPTION
Fixes #214

This hides all references to payout actions on the front-end, nothing changed in functions/data.